### PR TITLE
Update CLI with tweet parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ twetch post --content "Hello World" --file file.png
 
 # Likes
 twetch like -t abda4a05b98a60e9098f0cccebe5948118189d1b161a0372c35fac654eb87e30
+
+# Tweet from Twetch
+twetch post --content "Hello Twitter from Twetch" --tweet y
+
+# Hide Twetch link from Twitter
+twetch post --content "Hello Twitter from Twetch" --hide y
 ```
 
 You can see additional commands and usage by running:

--- a/cli
+++ b/cli
@@ -56,10 +56,19 @@ require('yargs')
 				.option('r', {
 					alias: 'reply',
 					describe: 'txid of post to reply to'
+				})
+				.option('t', {
+					alias: 'tweet',
+					describe: 'tweet from twetch'
+				})
+				.option('h', {
+					alias: 'hide',
+					describe: 'hide tweet from twetch link'
 				}),
 		async argv => {
 			const payload = {
 				bContent: argv.file ? undefined : argv.content,
+				payParams: { tweetFromTwetch: argv.tweet || false, hideTweetFromTwetchLink: argv.hide || false },
 				mapComment: (argv.file && argv.content ? argv.content : '') || '',
 				mapReply: argv.reply || 'null'
 			};


### PR DESCRIPTION
Update Command Line Interface to support two parameters

--tweet (any_value) - add to command to tweet from twetch

--hide (any_value) - add to command to hide tweet from twetch link

Example:

twetch post --content "Did I tweet from twetch this time and hide the link?" --tweet y --hide y

To ignore these parameters, simply do not set them.

Paymail is:

cryptoacorns@moneybutton.com